### PR TITLE
Fix error in updating packer

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -8,7 +8,7 @@ PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PAC
 if [ ! -f "${CIRCLECI_CACHE_DIR}/packer" ] || [[ ! "$(packer version)" =~ "Packer v${PACKER_VERSION}" ]]; then
   wget -O /tmp/packer.zip "${PACKER_URL}"
   echo "${PACKER_SHA1SUM} /tmp/packer.zip" | sha1sum --check -
-  unzip -ofd "${CIRCLECI_CACHE_DIR}" /tmp/packer.zip
+  unzip -oud "${CIRCLECI_CACHE_DIR}" /tmp/packer.zip
 fi
 
 packer version

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -2,12 +2,12 @@
 set -e
 CIRCLECI_CACHE_DIR="${HOME}/bin"
 PACKER_VERSION="0.12.1"
-PACKER_SHA1SUM="8b6c79c88d69be9205ebf43ba1111f6cec2cff04"
+PACKER_CHECKSUM="456e6245ea95705191a64e0556d7a7ecb7db570745b3b4b2e1ebf92924e9ef95"
 PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
 
 if [ ! -f "${CIRCLECI_CACHE_DIR}/packer" ] || [[ ! "$(packer version)" =~ "Packer v${PACKER_VERSION}" ]]; then
   wget -O /tmp/packer.zip "${PACKER_URL}"
-  echo "${PACKER_SHA1SUM} /tmp/packer.zip" | sha1sum --check -
+  echo "${PACKER_CHECKSUM} /tmp/packer.zip" | sha256sum --check -
   unzip -oud "${CIRCLECI_CACHE_DIR}" /tmp/packer.zip
 fi
 


### PR DESCRIPTION
I made a mistake in the last PR when picking my flags for unzip `-f` doesn't create new files, however `-u` will. Also it turns out the packer.io publishes sha256 checksums so I switched to using those.